### PR TITLE
added file omega.py for handling omega data

### DIFF
--- a/hexrd/config/imageseries.py
+++ b/hexrd/config/imageseries.py
@@ -7,12 +7,24 @@ from hexrd import imageseries
 
 class ImageSeriesConfig(Config):
 
-    def _open(self):
-        self._imser = imageseries.open(self.filename, self.format, **self.args)
+    def __init__(self, cfg):
+        super(ImageSeriesConfig, self).__init__(cfg)
+        self._imser = None
+        self._omseries = None
 
-    def _meta(self):
-        pass # to be done later
+    @property
+    def imageseries(self):
+        """return the imageseries without checking for omega metadata"""
+        if self._imser is None:
+            self._imser = imageseries.open(self.filename, self.format, **self.args)
+        return self._imser
 
+    @property
+    def omegaseries(self):
+        """return the imageseries and ensure it has omega metadata"""
+        if self._omseries is None:
+            self._omseries = imageseries.omega.OmegaImageSeries(self.imageseries)
+        return self._omseries
 
     @property
     def filename(self):

--- a/hexrd/coreutil.py
+++ b/hexrd/coreutil.py
@@ -168,21 +168,9 @@ def initialize_experiment(cfg):
 
     pd = ws.activeMaterial.planeData
 
-    isfile = cfg.image_series.filename
-    isfmt = cfg.image_series.format
-    isargs = cfg.image_series.args
     # detector data
     try:
-        reader = ReadGE(isfile, fmt=isfmt, **isargs)
-        #reader = ReadGE(
-        #    [(f, image_start) for f in cfg.image_series.files],
-        #    np.radians(cfg.image_series.omega.start),
-        #    np.radians(cfg.image_series.omega.step),
-        #    subtractDark=dark is not None, # TODO: get rid of this
-        #    dark=dark,
-        #    doFlip=flip is not None,
-        #    flipArg=flip, # TODO: flip=flip
-        #    )
+        reader = ReadGE(cfg.image_series.omegaseries)
     except IOError:
         logger.info("raw data not found, skipping reader init")
         reader = None

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -20,7 +20,6 @@ from hexrd.xrd import rotations as rot
 from hexrd.xrd import symmetry as sym
 from hexrd.xrd import transforms as xf
 from hexrd.xrd import transforms_CAPI as xfcapi
-from hexrd.xrd import image_io
 
 from hexrd.xrd import xrdutil
 
@@ -74,7 +73,7 @@ def generate_orientation_fibers(eta_ome, chi, threshold, seed_hkl_ids, fiber_ndi
 
     params = {
         'bMat':bMat,
-        'chi':chi,   
+        'chi':chi,
         'csym':csym,
         'fiber_ndiv':fiber_ndiv,
          }
@@ -114,7 +113,7 @@ def generate_orientation_fibers(eta_ome, chi, threshold, seed_hkl_ids, fiber_ndi
                 eta_c = eta_ome.etaEdges[0] + (0.5 + coms[i][ispot][1])*del_eta
                 input_p.append(
                     np.hstack(
-                        [hkls[:, pd_hkl_ids[i]], 
+                        [hkls[:, pd_hkl_ids[i]],
                          tTh[pd_hkl_ids[i]], eta_c, ome_c]
                     )
                 )
@@ -138,7 +137,7 @@ def generate_orientation_fibers(eta_ome, chi, threshold, seed_hkl_ids, fiber_ndi
         paramMP = None # clear paramMP
     elapsed = (time.time() - start)
     logger.info("fiber generation took %.3f seconds", elapsed)
-    
+
     return np.hstack(qfib)
 
 
@@ -157,7 +156,7 @@ def discretefiber_reduced(params_in):
     fiber_ndiv = paramMP['fiber_ndiv']
 
     hkl = params_in[:3].reshape(3, 1)
-        
+
     gVec_s = xfcapi.anglesToGVec(
         np.atleast_2d(params_in[3:]),
         chi=chi,
@@ -421,11 +420,8 @@ def find_orientations(cfg, hkls=None, clean=False, profile=False):
     md = dict(zip([matl[i].name for i in range(len(matl))], matl))
     pd = md[cfg.material.active].planeData
 
-    # make image_series, which must be an OmegaImageSeries
-    image_series = image_io.OmegaImageSeries(
-        cfg.image_series.filename,
-        fmt=cfg.image_series.format,
-        **cfg.image_series.args)
+    # make image_series
+    image_series = cfg.image_series.omegaseries
 
     # need instrument cfg later on down...
     instr_cfg = get_instrument_parameters(cfg)

--- a/hexrd/imageseries/__init__.py
+++ b/hexrd/imageseries/__init__.py
@@ -5,6 +5,7 @@ and a function for loading. Adapters for particular
 data formats are managed in the "load" subpackage.
 """
 from .baseclass import ImageSeries
+from . import imageseriesabc
 from . import load
 from . import save
 from . import stats

--- a/hexrd/imageseries/__init__.py
+++ b/hexrd/imageseries/__init__.py
@@ -6,9 +6,10 @@ data formats are managed in the "load" subpackage.
 """
 from .baseclass import ImageSeries
 from . import load
-from . import process
 from . import save
 from . import stats
+from . import process
+from . import omega
 
 def open(filename, format=None, **kwargs):
     # find the appropriate adapter based on format specified

--- a/hexrd/imageseries/omega.py
+++ b/hexrd/imageseries/omega.py
@@ -4,6 +4,27 @@
 """
 import numpy as np
 
+from .baseclass import ImageSeries
+
+OMEGA_KEY = 'omega'
+
+class OmegaImageSeries(ImageSeries):
+    """ImageSeries with omega metadata"""
+    def __init__(self, ims):
+        """This class is initialized with an existing imageseries"""
+        # check for omega metadata
+        if OMEGA_KEY not in ims.metadata:
+            raise RuntimeError('Imageseries has no omega metadata')
+
+        # use the imageseries as the adapter, as it may be a processed imageseries
+        super(OmegaImageSeries, self).__init__(ims)
+
+    @property
+    def omega(self):
+        """return omega range array (nframes, 2)"""
+        return self.metadata[OMEGA_KEY]
+
+
 class OmegaWedges(object):
     """piecewise linear omega ranges"""
     def __init__(self, nframes):

--- a/hexrd/imageseries/omega.py
+++ b/hexrd/imageseries/omega.py
@@ -1,0 +1,74 @@
+"""Handle omega (specimen rotation) metadata
+
+* OmegaWedges class specifies omega metadata in wedges
+"""
+import numpy as np
+
+class OmegaWedges(object):
+    """piecewise linear omega ranges"""
+    def __init__(self, nframes):
+        """Constructor for OmegaWedge"""
+	self.nframes = nframes
+        self._wedges = []
+    #
+    # ============================== API
+    #
+    @property
+    def omegas(self):
+        """n x 2 array of omega values, one per frame"""
+        if self.nframes != self.wframes:
+            msg = "number of frames (%s) does not match "\
+                  "number of wedge frames (%s)" %(self.nframes, self.wframes)
+            raise OmegaWedgesError(msg)
+
+        oa = np.zeros((self.nframes, 2))
+        wstart = 0
+        for w in self.wedges:
+            ns = w['nsteps']
+            wr = range(wstart, wstart + ns)
+            wa0 = np.linspace(w['ostart'], w['ostop'], ns + 1)
+            oa[wr, 0] = wa0[:-1]
+            oa[wr, 1] = wa0[1:]
+
+        return oa
+
+    @property
+    def nwedges(self):
+        """number of wedges"""
+        return len(self._wedges)
+
+    @property
+    def wedges(self):
+        """list of wedges (dictionary)"""
+        return self._wedges
+
+    def addwedge(self, ostart, ostop, nsteps, loc=None):
+        """add wedge to list"""
+        d = dict(ostart=ostart, ostop=ostop, nsteps=nsteps)
+        if loc is None:
+            loc = self.nwedges
+
+        self.wedges.insert(loc, d)
+
+    def delwedge(self, i):
+        """delete wedge number i"""
+        self.wedges.pop(i)
+
+    @property
+    def wframes(self):
+        """number of frames in wedges"""
+        wf = [w['nsteps'] for w in self.wedges]
+        return np.int(np.sum(wf))
+
+    def save_omegas(self, fname):
+        """save omegas to text file"""
+        np.save(fname, self.omegas)
+
+    pass  # end class
+
+
+class OmegaWedgesError(Exception):
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)

--- a/hexrd/xrd/xrdutil.py
+++ b/hexrd/xrd/xrdutil.py
@@ -1839,18 +1839,14 @@ class GenerateEtaOmeMaps(object):
                                               npdiv=npdiv, quiet=False,
                                               compute_areas_func=gutil.compute_areas)
             ij_patches.append(patches)
-        # DEBUGGING # mxf = num.amax([image_series[i] for i in range(image_series.nframes)], axis=0)
-        # DEBUGGING # xs = num.hstack([ij_patches[0][i][-1][1] for i in num.linspace(0, 1436, num=360, dtype=int)])
-        # DEBUGGING # ys = num.hstack([ij_patches[0][i][-1][0] for i in num.linspace(0, 1436, num=360, dtype=int)])
-        # DEBUGGING # import pdb; pdb.set_trace()
         # initialize maps and loop
         pbar = ProgressBar(
             widgets=[Bar('>'), ' ', ETA(), ' ', ReverseBar('<')],
-            maxval=image_series.nframes
+            maxval=len(image_series)
             ).start()
         maps = num.zeros((len(active_hkls), len(self._omegas), len(self._etas)))
         print "maps.shape: ", maps.shape
-        for i_ome in range(image_series.nframes):
+        for i_ome in range(len(image_series)):
             pbar.update(i_ome)
             this_frame = image_series[i_ome]
             if threshold is not None:


### PR DESCRIPTION
currently has OmegaWedges for generating metadata; We can include other tools for omega imageseries here. For example, we could move OmegaImageSeries from image_io to omega.py. However, we need to examine how it is used and what is the best way to move forward. We may want to just get rid of it eventually; it was developed to be used by ReadGE, and we want to get rid of that.